### PR TITLE
Delete All Methods

### DIFF
--- a/client/src/app/families/family.service.spec.ts
+++ b/client/src/app/families/family.service.spec.ts
@@ -403,6 +403,21 @@ describe('FamilyService', () => {
     }));
   });
 
+  describe('When deleteAll() is called', () => {
+    it('talks to correct Endpoints', waitForAsync(() => {
+      // Checking whether the item was actually deleted should happen in E2E probably
+      const targetItems: Family[] = testFamilies; //This will be a duplicate
+
+      const mockedDelete = spyOn(httpClient, 'delete').and.returnValue(of(targetItems));
+
+      familyService.deleteAll(targetItems);
+
+      expect(mockedDelete)
+        .withContext('calls delete')
+        .toHaveBeenCalledTimes(3);
+    }));
+  });
+
   // describe('When modifyMass() is called', () => {
   //   let copiedItems = [];
   //   let emptyItem: Family = {

--- a/client/src/app/families/family.service.ts
+++ b/client/src/app/families/family.service.ts
@@ -226,39 +226,19 @@ export class FamilyService {
     return this.httpClient.delete<Family>(`${this.familyUrl}/${id}`);
   }
 
-  // modifyMass(newProps:Family,oldItems:Family[]) {
-  //   //Same as inventory items. Not sure when we'd ever need to use this, but it's here.
-  //   const newItems: Family[] = [];
-  //   for (let i = 0; i < oldItems.length -1; i ++) {
-  //     const baseItem: Family = {
-  //       _id:undefined,
-  //       name:undefined,
-  //       students:undefined,
-  //       time:undefined
-  //     }
-  //     //Create a new array of items, initialized as empty.
-  //     newItems.push(baseItem);
+  reloadPage() { //Not really a good way to test this.
+    setTimeout(() => {
+      window.location.reload();
+      //Why on Earth does it need such a long delay to handle this???
+    }, 2000);
+  }
 
-  //     if (newProps.name != undefined) {
-  //       newItems[i].name = newProps.name;
-  //     } else {
-  //       newItems[i].name = oldItems[i].name;
-  //     }
-
-  //     if (newProps.students != undefined) {
-  //       newItems[i].students = newProps.students;
-  //     } else {
-  //       newItems[i].students = oldItems[i].students;
-  //     }
-
-  //     if (newProps.time != undefined) {
-  //       newItems[i].time = newProps.time;
-  //     } else {
-  //       newItems[i].time = oldItems[i].time;
-  //     }
-
-  //     this.addFamily(newItems[i]).subscribe(); //Need to subscribe for changes to take effect
-  //     this.deleteFamily(oldItems[i]._id).subscribe();
-  //   }
-  // }
+  deleteAll(oldItems:Family[]) {
+    //Same as inventory items. Not sure when we'd ever need to use this, but it's here.
+    if (oldItems.length > 0) {
+      for (let i = 0; i < oldItems.length; i ++) {
+        this.deleteFamily(oldItems[i]._id).subscribe();
+      }
+    }
+  }
 }

--- a/client/src/app/families/family_list.component.html
+++ b/client/src/app/families/family_list.component.html
@@ -58,23 +58,11 @@
             color="accent"
             type="back"
             [style.height.px]=55
-            (click)="revealReset()"
+            (click)="resetStudents()"
             data-test="resetFamiliesButton"
             >
             List Reset
           </button>
-          @if (resetVisible()) {
-              <button
-              mat-raised-button
-              type="button"
-              color="warn"
-              type="back"
-              [style.height.px]=55
-              data-test="resetAllFamiliesButton"
-              >
-            TODO Clear All
-            </button>
-          }
         </div>
 
         <div class="flex-row gap-8 flex-wrap">

--- a/client/src/app/families/family_list.component.spec.ts
+++ b/client/src/app/families/family_list.component.spec.ts
@@ -88,11 +88,11 @@ describe('Family list', () => {
     expect(familyList.errMsg()).toBeUndefined();
   });
 
-  it("correctly handles the 'Location Reset' button", () => {
-    expect(familyList.resetVisible()).toEqual(false);
-    familyList.revealReset();
-    expect(familyList.resetVisible()).toEqual(true);
-  });
+  // it("correctly handles the 'Location Reset' button", () => {
+  //   expect(familyList.resetVisible()).toEqual(false);
+  //   familyList.revealReset();
+  //   expect(familyList.resetVisible()).toEqual(true);
+  // });
 
   //Irellevant, eventually add a test for list clear.
 

--- a/client/src/app/families/family_list.component.ts
+++ b/client/src/app/families/family_list.component.ts
@@ -70,7 +70,7 @@ export class FamilyListComponent {
   itemStudents = signal<number|undefined>(this.familyService.savedFamilyStudents);
   itemTime = signal<string|undefined>(this.familyService.savedFamilyTime);
   sortBy = signal<string|undefined>(this.familyService.savedFamilySortBy); //When undefined, sorts by name.
-  resetVisible = signal<boolean|undefined>(false);//Reset button is initially hidden.
+  //resetVisible = signal<boolean|undefined>(false);//Reset button is initially hidden.
 
 
   filteredGradeOptions = computed(() => {
@@ -303,15 +303,28 @@ export class FamilyListComponent {
     return schooledArray;
   })
 
-  revealReset() {
-    this.resetVisible.set(true);
-    this.snackBar.open(
-      `Press 'Clear all Families' to proceed. This CANNOT be undone. `,
-      'OK',
-      { duration: 6000 }
-    );
-  }
+  // revealReset() {
+  //   this.resetVisible.set(true);
+  //   this.snackBar.open(
+  //     `Press 'Clear all Families' to proceed. This CANNOT be undone. `,
+  //     'OK',
+  //     { duration: 6000 }
+  //   );
+  // }
 
+  //Not a great way to test this since it reloads the page...
+  resetStudents() {
+    const warning = confirm("This will delete ALL families. Are you sure?");
+    if (warning == true) {
+      this.familyService.deleteAll(this.filteredFamilies());
+      this.snackBar.open(
+        `Family List reset. Please wait for page to reload...`,
+        'OK',
+        { duration: 6000 }
+      );
+      this.familyService.reloadPage();
+    }
+  }
 
   //Not relevant for families? Will still want a clear all families button.
   // resetLocations() {

--- a/client/src/app/grade_list/grade_list.component.html
+++ b/client/src/app/grade_list/grade_list.component.html
@@ -64,24 +64,11 @@
             color="accent"
             type="back"
             [style.height.px]=55
-            (click)="revealReset()"
+            (click)="resetFamilies()"
             data-test="resetLocationButton"
             >
             List Reset
           </button>
-          @if (resetVisible()) {
-              <button
-              mat-raised-button
-              type="button"
-              color="warn"
-              type="back"
-              [style.height.px]=55
-              data-test="resetListButton"
-              >
-            Clear All Lists
-            </button>
-          }
-
         </div>
 
         <div class="flex-row gap-8 flex-wrap">

--- a/client/src/app/grade_list/grade_list.component.spec.ts
+++ b/client/src/app/grade_list/grade_list.component.spec.ts
@@ -120,11 +120,11 @@ describe('Grade List', () => {
     expect(gradeList.errMsg()).toBeUndefined();
   });
 
-  it("correctly handles the 'Location Reset' button", () => {
-    expect(gradeList.resetVisible()).toEqual(false);
-    gradeList.revealReset();
-    expect(gradeList.resetVisible()).toEqual(true);
-  });
+  // it("correctly handles the 'Location Reset' button", () => {
+  //   expect(gradeList.resetVisible()).toEqual(false);
+  //   gradeList.revealReset();
+  //   expect(gradeList.resetVisible()).toEqual(true);
+  // });
 
   it("correctly populates the inventory with items from grade list", () => {
     expect(gradeList.populateAllowed).toBeTrue();

--- a/client/src/app/grade_list/grade_list.component.ts
+++ b/client/src/app/grade_list/grade_list.component.ts
@@ -264,15 +264,28 @@ export class GradeListComponent {
     return schooledArray;
   })
 
-  revealReset() {
-    // this.resetVisible = true;
-    this.resetVisible.set(true);
-    this.snackBar.open(
-      `Press 'Clear all Lists' to proceed. This CANNOT be undone. `,
-      'OK',
-      { duration: 6000 }
-    );
+  resetFamilies() {
+    const warning = confirm("This will delete ALL grade lists. Are you sure?");
+    if (warning == true) {
+      this.gradeListService.deleteAll(this.filteredItems());
+      this.snackBar.open(
+        `Grade Lists reset. Please wait for page to reload...`,
+        'OK',
+        { duration: 6000 }
+      );
+      this.gradeListService.reloadPage();
+    }
   }
+
+  // revealReset() {
+  //   // this.resetVisible = true;
+  //   this.resetVisible.set(true);
+  //   this.snackBar.open(
+  //     `Press 'Clear all Lists' to proceed. This CANNOT be undone. `,
+  //     'OK',
+  //     { duration: 6000 }
+  //   );
+  // }
 
   //Helper function to autofill grade/school for per-grade addition.
   updateOrigin(school_val?: string, grade_val?: string) {

--- a/client/src/app/grade_list/grade_list.service.spec.ts
+++ b/client/src/app/grade_list/grade_list.service.spec.ts
@@ -523,6 +523,21 @@ describe('GradeListService', () => {
     }));
   });
 
+  describe('When deleteAll() is called', () => {
+    it('talks to correct Endpoints', waitForAsync(() => {
+      // Checking whether the item was actually deleted should happen in E2E probably
+      const targetItems: RequiredItem[] = testItems; //This will be a duplicate
+
+      const mockedDelete = spyOn(httpClient, 'delete').and.returnValue(of(targetItems));
+
+      gradeService.deleteAll(targetItems);
+
+      expect(mockedDelete)
+        .withContext('calls delete')
+        .toHaveBeenCalledTimes(3);
+    }));
+  });
+
   describe('When modifyMass() is called', () => {
     let copiedItems = [];
     let copiedItemsIDless = [];
@@ -580,7 +595,7 @@ describe('GradeListService', () => {
 
       expect(mockedDelete)
         .withContext('calls delete')
-        .toHaveBeenCalledTimes(1);
+        .toHaveBeenCalledTimes(2);
 
       //Obviously we could do more testing here...
       // but it at least gets us to coverage, and it works for now.
@@ -616,7 +631,7 @@ describe('GradeListService', () => {
 
       expect(mockedDelete)
         .withContext('calls delete')
-        .toHaveBeenCalledTimes(1);
+        .toHaveBeenCalledTimes(2);
 
       //Obviously we could do more testing here...
       // but it at least gets us to coverage, and it works for now.

--- a/client/src/app/grade_list/grade_list.service.ts
+++ b/client/src/app/grade_list/grade_list.service.ts
@@ -186,7 +186,7 @@ export class GradeListService {
     setTimeout(() => {
       window.location.reload();
       //Why on Earth does it need such a long delay to handle this???
-    }, 3500);
+    }, 2000);
   }
 
   alreadyInInventory( newItem: RequiredItem, inventory: InventoryItem[]): boolean {
@@ -312,11 +312,20 @@ export class GradeListService {
     return this.httpClient.delete<RequiredItem>(`${this.gradeListUrl}/${id}`);
   }
 
+  deleteAll(oldItems:RequiredItem[]) {
+    //Same as inventory items. Not sure when we'd ever need to use this, but it's here.
+    if (oldItems.length > 0) {
+      for (let i = 0; i < oldItems.length; i ++) {
+        this.deleteItem(oldItems[i]._id).subscribe();
+      }
+    }
+  }
+
   modifyMass(newProps:RequiredItem,oldItems:RequiredItem[]) {
     //We first need to copy the items into a new array. oldItems is connected to a signal or something.
     //Redoing the whole database is not a great way to do this. For now we're doing it anyways.
     const newItems: RequiredItem[] = [];
-    for (let i = 0; i < oldItems.length -1; i ++) {
+    for (let i = 0; i < oldItems.length; i ++) {
       //Location is probably the only one this will be used for, but you never know.
       //id is never overwritten; necessary to delete and replace.
       const baseItem: RequiredItem = {

--- a/client/src/app/inventory/inventory.service.spec.ts
+++ b/client/src/app/inventory/inventory.service.spec.ts
@@ -415,4 +415,19 @@ describe('InventoryService', () => {
       });
     }));
   });
+
+  describe('When deleteAll() is called', () => {
+    it('talks to correct Endpoints', waitForAsync(() => {
+      // Checking whether the item was actually deleted should happen in E2E probably
+      const targetItems: InventoryItem[] = testItems; //This will be a duplicate
+
+      const mockedDelete = spyOn(httpClient, 'delete').and.returnValue(of(targetItems));
+
+      inventoryService.deleteAll(targetItems);
+
+      expect(mockedDelete)
+        .withContext('calls delete')
+        .toHaveBeenCalledTimes(3);
+    }));
+  });
 });

--- a/client/src/app/inventory/inventory.service.ts
+++ b/client/src/app/inventory/inventory.service.ts
@@ -230,6 +230,22 @@ export class InventoryService {
     return this.httpClient.delete<InventoryItem>(`${this.inventoryUrl}/${id}`);
   }
 
+  deleteAll(oldItems:InventoryItem[]) {
+    //Same as inventory items. Not sure when we'd ever need to use this, but it's here.
+    if (oldItems.length > 0) {
+      for (let i = 0; i < oldItems.length; i ++) {
+        this.deleteItem(oldItems[i]._id).subscribe();
+      }
+    }
+  }
+
+  reloadPage() { //Not really a good way to test this.
+    setTimeout(() => {
+      window.location.reload();
+      //Why on Earth does it need such a long delay to handle this???
+    }, 2000);
+  }
+
   modifyMass(newProps:InventoryItem,oldItems:InventoryItem[]): Observable<void> {
     if (oldItems.length === 0) {
       return of(void 0);

--- a/client/src/app/inventory/inventory_list.component.html
+++ b/client/src/app/inventory/inventory_list.component.html
@@ -73,24 +73,11 @@
             color="accent"
             type="back"
             [style.height.px]=55
-            (click)="revealReset()"
+            (click)="resetInventory()"
             data-test="resetLocationButton"
             >
-            Location Reset
+            Reset Inventory
           </button>
-          @if (resetVisible()) {
-              <button
-              mat-raised-button
-              type="button"
-              color="warn"
-              type="back"
-              [style.height.px]=55
-              data-test="resetLocationButton"
-              (click)="resetLocations()"
-              >
-            Clear All Locations
-            </button>
-          }
 
         </div>
 

--- a/client/src/app/inventory/inventory_list.component.ts
+++ b/client/src/app/inventory/inventory_list.component.ts
@@ -236,6 +236,19 @@ export class InventoryListComponent {
     }
   }
 
+  resetInventory() {
+    const warning = confirm("This will delete ALL items. Are you sure?");
+    if (warning == true) {
+      this.inventoryService.deleteAll(this.filteredItems());
+      this.snackBar.open(
+        `Inventory reset. Please wait for page to reload...`,
+        'OK',
+        { duration: 6000 }
+      );
+      this.inventoryService.reloadPage();
+    }
+  }
+
   adjustStock(item: InventoryItem, delta: number) {
     const newStocked = (item.stocked ?? 0) + delta;
     let updatedItem: Partial<InventoryItem>;

--- a/client/src/testing/family.service.mock.ts
+++ b/client/src/testing/family.service.mock.ts
@@ -15,7 +15,7 @@ import { FamilyService } from 'src/app/families/family.service';
 })
 
 //'modifyMass'
-export class MockFamilyService implements Pick<FamilyService, 'getFamilies' | 'filterFamilies' | 'addFamily' | 'deleteFamily'| 'updateSavedSearch'|'getSchools'> {
+export class MockFamilyService implements Pick<FamilyService, 'getFamilies' | 'filterFamilies' | 'addFamily' | 'deleteFamily'| 'updateSavedSearch'|'getSchools' | 'deleteAll'> {
   savedFamilyName = ''; //Per-session saved value for name search bar.
   savedFamilySchool = '';
   savedFamilyGrade = '';
@@ -157,6 +157,13 @@ export class MockFamilyService implements Pick<FamilyService, 'getFamilies' | 'f
     // Send post request to add a new item with the item data as the body.
     // `res.id` should be the MongoDB ID of the newly added `Item`.
     return of(MockFamilyService.emptyFamily);
+  }
+
+  deleteAll(oldItems:Family[]) {
+    //Same as inventory items. Not sure when we'd ever need to use this, but it's here.
+    for (let i = 0; i < oldItems.length; i ++) {
+      this.deleteFamily(oldItems[i]._id).subscribe();
+    }
   }
 
   // modifyMass(newProps:Family,oldItems:Family[]) {

--- a/client/src/testing/grade_list.service.mock.ts
+++ b/client/src/testing/grade_list.service.mock.ts
@@ -14,7 +14,7 @@ import { GradeListService } from 'src/app/grade_list/grade_list.service';
 @Injectable({
   providedIn: AppComponent
 })
-export class MockGradeListService implements Pick<GradeListService, 'getItems' | 'filterItems' | 'addItem' | 'addItemToInventory' | 'deleteItem'| 'updateSavedSearch'| 'modifyMass'|'getSchools'|'reloadPage'|'alreadyInInventory'> {
+export class MockGradeListService implements Pick<GradeListService, 'getItems' | 'filterItems' | 'addItem' | 'addItemToInventory' | 'deleteItem'| 'updateSavedSearch'| 'modifyMass'|'getSchools'|'reloadPage'|'alreadyInInventory'|'deleteAll'> {
   savedInventoryName = ''; //Per-session saved value for name search bar.
   savedInventoryGrade = ''; //Per-session saved value for location search bar.
   savedInventorySchool = ''; //Per-session saved value for location search bar.
@@ -115,6 +115,13 @@ export class MockGradeListService implements Pick<GradeListService, 'getItems' |
   /* eslint-disable @typescript-eslint/no-unused-vars */
   getItems(_filters: { name?: string; stocked?: number; desc?: string; location?: string; type?: string;}): Observable<RequiredItem[]> {
     return of(MockGradeListService.testItems);
+  }
+
+  deleteAll(oldItems:RequiredItem[]) {
+    //Same as inventory items. Not sure when we'd ever need to use this, but it's here.
+    for (let i = 0; i < oldItems.length; i ++) {
+      this.deleteItem(oldItems[i]._id).subscribe();
+    }
   }
 
   reloadPage() {

--- a/client/src/testing/inventory.service.mock.ts
+++ b/client/src/testing/inventory.service.mock.ts
@@ -12,7 +12,7 @@ import { InventoryService } from 'src/app/inventory/inventory.service';
 @Injectable({
   providedIn: AppComponent
 })
-export class MockInventoryService implements Pick<InventoryService, 'getItems' | 'filterItems' | 'addItem' | 'deleteItem'| 'updateSavedSearch'| 'modifyMass' | 'updateItem'> {
+export class MockInventoryService implements Pick<InventoryService, 'getItems' | 'filterItems' | 'addItem' | 'deleteItem'| 'updateSavedSearch'| 'modifyMass' | 'updateItem' | 'deleteAll'> {
   savedInventoryName = ''; //Per-session saved value for name search bar.
   savedInventoryLocation = ''; //Per-session saved value for location search bar.
   savedInventoryStocked = 0; //Per-session saved value for stocked search bar.
@@ -137,6 +137,13 @@ export class MockInventoryService implements Pick<InventoryService, 'getItems' |
         );
       })
     ).pipe(switchMap(() => of(void 0)));
+  }
+
+  deleteAll(oldItems:InventoryItem[]) {
+    //Same as inventory items. Not sure when we'd ever need to use this, but it's here.
+    for (let i = 0; i < oldItems.length; i ++) {
+      this.deleteItem(oldItems[i]._id).subscribe();
+    }
   }
 
   filterItems(items: InventoryItem[], filters: {


### PR DESCRIPTION
The grade list, family list, and inventory list now have proper reset methods that remove all items; and now use a proper warning prompt. Tests have been added for the deleteAll methods, but annoyingly, I can't find a good way to test the 'resetAll' methods in each of the list components, as these require reloading the page. ...In lieu of figuring this out, I've added unnecessary if statements to the delete-all methods in order to bring branch coverage above 80% X-)